### PR TITLE
feat(api): 添加心跳请求结构体

### DIFF
--- a/api/login/v1/login.go
+++ b/api/login/v1/login.go
@@ -25,6 +25,15 @@ type LoginRes struct {
 	//Introduction string `json:"introduction" orm:"introduction"   dc:"简介"`
 }
 
+// 心跳
+type HeartBeatsReq struct {
+	g.Meta `path:"/user/heartbeat" method:"POST" tag:"HeartBeats" summary:"心跳请求"`
+}
+
+type HeartBeatsRes struct {
+	UserId int `json:"id"`
+}
+
 // 登出
 
 type LogoutReq struct {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"suask/internal/controller/favorite"
 	"suask/internal/controller/history"
+	"suask/internal/controller/login"
 	"suask/internal/controller/notification"
 	"suask/internal/controller/questions"
 	"suask/internal/controller/register"
@@ -49,6 +50,7 @@ var (
 					}
 					group.Bind(
 						user.User.Info,
+						login.Login.HeartBeats,
 						questions.PublicQuestions,
 						questions.QuestionDetail.GetDetail,
 						user.User.UpdateUserInfo,

--- a/internal/cmd/loginAuth.go
+++ b/internal/cmd/loginAuth.go
@@ -147,6 +147,7 @@ func isMustLoginPath(path string) bool {
 		"/notification",
 		"/questions/public",
 		"/teacher/question",
+		"/user/heartbeat",
 	}
 	for _, v := range mustLoginPath {
 		if strings.HasPrefix(path, v) {

--- a/internal/controller/login/login.go
+++ b/internal/controller/login/login.go
@@ -2,21 +2,29 @@ package login
 
 import (
 	"context"
-	"suask/api/login/v1"
+	v1 "suask/api/login/v1"
+	"suask/internal/consts"
+
+	"github.com/gogf/gf/v2/util/gconv"
 )
 
 type cLogin struct{}
 
 var Login cLogin
 
-func (c *cLogin) Login(ctx context.Context, req v1.LoginReq) (res v1.LoginRes, err error) {
+func (c *cLogin) Login(ctx context.Context, req *v1.LoginReq) (res *v1.LoginRes, err error) {
 	return
 }
 
-func (c *cLogin) Logout(ctx context.Context, req v1.LogoutReq) (res v1.LogoutRes, err error) {
+func (c *cLogin) Logout(ctx context.Context, req *v1.LogoutReq) (res *v1.LogoutRes, err error) {
 	return
 }
 
-func (c *cLogin) RefreshToken(ctx context.Context, req v1.RefreshTokenReq) (res v1.RefreshTokenRes, err error) {
+func (c *cLogin) HeartBeats(ctx context.Context, req *v1.HeartBeatsReq) (res *v1.HeartBeatsRes, err error) {
+	userId := gconv.Int(ctx.Value(consts.CtxId))
+	return &v1.HeartBeatsRes{UserId: userId}, nil
+}
+
+func (c *cLogin) RefreshToken(ctx context.Context, req *v1.RefreshTokenReq) (res *v1.RefreshTokenRes, err error) {
 	return
 }

--- a/internal/logic/login/login.go
+++ b/internal/logic/login/login.go
@@ -18,6 +18,11 @@ func (s sLogin) Logout(ctx context.Context) error {
 	panic("implement me")
 }
 
+func (s sLogin) HeartBeats(ctx context.Context) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 func init() {
 	service.RegisterLogin(New())
 }

--- a/internal/service/login.go
+++ b/internal/service/login.go
@@ -1,3 +1,8 @@
+// ================================================================================
+// Code generated and maintained by GoFrame CLI tool. DO NOT EDIT.
+// You can delete these comments if you wish manually maintain this interface file.
+// ================================================================================
+
 package service
 
 import (
@@ -9,6 +14,7 @@ type (
 	ILogin interface {
 		Login(ctx context.Context, in model.UserLoginInput) error
 		Logout(ctx context.Context) error
+		HeartBeats(ctx context.Context) error
 	}
 )
 


### PR DESCRIPTION
feat(internal/cmd): 添加心跳请求处理
feat(internal/cmd): 心跳请求加入必登录路径
feat(internal/controller/login): 添加心跳请求处理逻辑
feat(internal/logic/login): 添加心跳请求服务接口
docs(internal/service): 添加心跳请求接口注释